### PR TITLE
removed pnpm-lock file from .gitignore to include in build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,6 @@
 .DS_Store
 *.pem
 package-lock.json
-pnpm-lock.yaml
 
 # debug
 npm-debug.log*


### PR DESCRIPTION
# Description
pnpm-lock file should be included in development branch. This commit just removes it from the gitignore.