### PR TITLE
Adjusted group schema to prevent duplicates, fixed error in group api…

### DIFF
--- a/app/api/groups/route.ts
+++ b/app/api/groups/route.ts
@@ -21,7 +21,7 @@ interface GroupBody {
   description: string;
   budget: number;
   user_id: ObjectId | string;
-  members: (ObjectId | string)[];
+  members?: (ObjectId | string)[];
 }
 
 export const POST = async(request: NextRequest): Promise<NextResponse> => {
@@ -30,12 +30,14 @@ export const POST = async(request: NextRequest): Promise<NextResponse> => {
     const body: GroupBody = await request.json();
     let inviteLink = nanoid(7);
 
+    const members = body.members ? body.members : []
+
     const group = await Group.create({
       name: body.name,
       description: body.description,
       budget: body.budget,
       admin_id: body.user_id,
-      members: [body.user_id, ...body.members],
+      members: [body.user_id, ...members],
       invite_link: inviteLink
     });
 

--- a/models/Group.ts
+++ b/models/Group.ts
@@ -48,6 +48,9 @@ const groupSchema: Schema = new Schema({
   }
 });
 
+groupSchema.index({ name: 1, description: 1, budget: 1, admin_id: 1}, { unique: true }); //prevents duplicates entries
+
 const Group: Model<IGroup> = mongoose.models.Group || mongoose.model<IGroup>("Group", groupSchema);
 
 export default Group;
+


### PR DESCRIPTION

# Description
This commit fixes the the possibility of duplicate groups being created by the same user. It also fixes an error caused by the last push to development that caused the post request for creating a group not to work.

## Related to the following Jira/Trello issue 
N/A

## Main changes explained:
Assigned body.members to a variable that will default to an empty array if no members are passed through the body.
Adjust Group schema to prevent duplicate entires. 

## How to test:
1. check into current branch
2. do `npm install` and `npm run dev` to run this PR locally
3, Try to create a group. It should work.
4. Try to create a group with the same exact info. It shouldnt work.