### PR TITLE
Olga/feature/friends and groups display

### DIFF
--- a/app/(dashboard)/friends/page.tsx
+++ b/app/(dashboard)/friends/page.tsx
@@ -1,3 +1,7 @@
+import Friends from "./ui/friends";
+
 export default function Page() {
-  return <p>Friends list will be here</p>;
+  return <div>
+    <Friends />
+  </div>;
 }

--- a/app/(dashboard)/friends/ui/friends.tsx
+++ b/app/(dashboard)/friends/ui/friends.tsx
@@ -1,16 +1,86 @@
-'use client'
+'use client';
 import React from 'react';
 import { useUserContext } from '../../../context/UserContext';
+import { Button } from '@/components/ui/button';
+import Image from 'next/image';
+import { useToast } from '@/hooks/use-toast';
+import { useRouter } from 'next/navigation';
+
 
 const Friends = () => {
-    const { userDetails, userGroups, userFriends } = useUserContext();
-    console.log(userDetails);
-    console.log(userGroups);
-    console.log(userFriends);
+  const { userDetails, userFriends } = useUserContext();
+
+  const { toast } = useToast();
+  const router = useRouter();
+  const handleDeleteFriend = async (friendId: string) => {
+    try {
+      const response = await fetch('api/users/removeFriend', {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          userId: userDetails._id,
+          friendId: friendId,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        console.error('Error deleting friend:', errorData.error);
+        return;
+      }
+
+      const result = await response.json();
+      console.log(result.message);
+      toast({
+        description: result.message,
+      });
+    } catch (error) {
+      console.error('Error deleting friend:', error);
+    }
+  };
 
   return (
-    <div>All your friends</div>
-  )
-}
+    <div className='p-4'>
+      <div className='flex items-center justify-between'>
+        {' '}
+        <h1 className='text-2xl font-semibold mb-4'>
+          Hi {userDetails.firstName || 'User'}!
+        </h1>
+        <Button
+          className='bg-solitude outline-none text-purple font-semibold hover:bg-purple hover:text-white  sm:hidden'
+          onClick={() => router.push('/friends/add')}>
+          Add Friend
+        </Button>
+      </div>
+      <p className='font-bold'>Your friends</p>
+      <ul className='mt-8'>
+        {userFriends.map((friend) => (
+          <li
+            key={friend._id}
+            className='flex items-center justify-between mb-2 p-2 border rounded-md bg-pampas'>
+            <div className='flex flex-wrap items-center'>
+              <Image
+                src={friend.image || '/images/logo/logo-icon.png'}
+                alt='Friend avatar'
+                width={100}
+                height={100}
+                className='w-10 h-10 rounded-full mx-4'
+              />
+              <span className='ml-4'>{`${friend.firstName} ${friend.lastName}`}</span>
+              <span className='ml-4 text-sm text-grey hidden sm:block'>{`${friend.email}`}</span>
+            </div>
+            <Button
+              variant='destructive'
+              onClick={() => handleDeleteFriend(friend._id)}>
+              Delete
+            </Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
 
-export default Friends
+export default Friends;

--- a/app/(dashboard)/friends/ui/friends.tsx
+++ b/app/(dashboard)/friends/ui/friends.tsx
@@ -1,0 +1,16 @@
+'use client'
+import React from 'react';
+import { useUserContext } from '../../../context/UserContext';
+
+const Friends = () => {
+    const { userDetails, userGroups, userFriends } = useUserContext();
+    console.log(userDetails);
+    console.log(userGroups);
+    console.log(userFriends);
+
+  return (
+    <div>All your friends</div>
+  )
+}
+
+export default Friends

--- a/app/(dashboard)/groups/add/ui/addGroupForm.tsx
+++ b/app/(dashboard)/groups/add/ui/addGroupForm.tsx
@@ -70,7 +70,7 @@ const NewGroupForm: React.FC = () => {
       ...members.map((member) => member._id).filter((id): id is string => id !== undefined),
     ];
 
-    console.log('AllGroupMembers', allGroupMembers);
+    //console.log('AllGroupMembers', allGroupMembers);
 
     await addNewGroupToDatabase({
       ...data,

--- a/app/(dashboard)/groups/page.tsx
+++ b/app/(dashboard)/groups/page.tsx
@@ -1,3 +1,5 @@
+import Groups from './ui/groups'
+
 export default function Page() {
-  return <p>Page to view a user groups</p>;
+  return <div><Groups/></div>;
 }

--- a/app/(dashboard)/groups/ui/groups.tsx
+++ b/app/(dashboard)/groups/ui/groups.tsx
@@ -23,10 +23,14 @@ console.log(userGroups)
   const { toast } = useToast();
   const router = useRouter();
 
-    
+//TO DO TO DO implement deletion    
     const handleDeleteGroup = (groupId : string) => {
-        console.log('deleting', groupId)
+      console.log('deleting', groupId);
+      toast({
+        description: 'Group successfully deleted!'
+      })
     }
+  
   return (
     <div className='p-4'>
       <div className='flex items-center justify-between'>

--- a/app/(dashboard)/groups/ui/groups.tsx
+++ b/app/(dashboard)/groups/ui/groups.tsx
@@ -1,0 +1,58 @@
+'use client';
+import React from 'react';
+import { useUserContext } from '../../../context/UserContext';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/hooks/use-toast';
+import { useRouter } from 'next/navigation';
+import { HoverView } from './hoverCard';
+
+interface Group {
+  _id: string;
+  name: string;
+  members: string[];
+  budget: number;
+  description: string;
+  expenses: string[];
+  invite_link: string;
+}
+
+const Groups = () => {
+  const { userDetails, userGroups } = useUserContext();
+
+console.log(userGroups)
+  const { toast } = useToast();
+  const router = useRouter();
+
+    
+    const handleDeleteGroup = (groupId : string) => {
+        console.log('deleting', groupId)
+    }
+  return (
+    <div className='p-4'>
+      <div className='flex items-center justify-between'>
+        {' '}
+        <h1 className='text-2xl font-semibold mb-4'>
+          Hi {userDetails.firstName || 'User'}!
+        </h1>
+        <Button
+          className='bg-solitude outline-none text-purple font-semibold hover:bg-purple hover:text-white  sm:hidden'
+          onClick={() => router.push('/groups/add')}>
+          Add Group
+        </Button>
+      </div>
+      <p className='font-bold'>Your groups</p>
+      <ul className='mt-8'>
+        {userGroups.map((group: Group) => (
+          <li
+            key={group._id}
+            className='flex items-center justify-between mb-2 p-2 border rounded-md bg-pampas'>
+                <HoverView group={group} />
+            <Button variant='destructive' onClick={()=>handleDeleteGroup(group._id)}>Delete</Button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Groups;

--- a/app/(dashboard)/groups/ui/hoverCard.tsx
+++ b/app/(dashboard)/groups/ui/hoverCard.tsx
@@ -1,0 +1,42 @@
+import { CalendarDays } from 'lucide-react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Button } from '@/components/ui/button';
+import {
+  HoverCard,
+  HoverCardContent,
+  HoverCardTrigger,
+} from '@/components/ui/hover-card';
+
+interface Group {
+  name: string;
+  description: string;
+  budget: number | string; 
+}
+
+interface HoverViewProps {
+  group: Group; 
+}
+
+export function HoverView({group}: HoverViewProps) {
+  return (
+    <HoverCard>
+      <HoverCardTrigger asChild>
+        <Button variant='link'>{group.name}</Button>
+      </HoverCardTrigger>
+      <HoverCardContent className='w-80'>
+        <div className='flex justify-between space-x-4'>
+          <div className='space-y-1'>
+            <h4 className='text-sm font-semibold'>Description</h4>
+            <p className='text-sm'>{group.description}</p>
+            <div className='flex items-center pt-2'>
+              <p>
+                Total budget: <span className='font-bold text-green-300'>{group.budget}</span>
+              </p>
+            </div>
+          </div>
+        </div>
+      </HoverCardContent>
+    </HoverCard>
+  );
+}

--- a/app/(dashboard)/home/page.tsx
+++ b/app/(dashboard)/home/page.tsx
@@ -1,63 +1,13 @@
 'use client';
 
+import { useUserContext } from '../../context/UserContext';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-
-import { useSession } from 'next-auth/react';
 import RecentActivity from './ui/recentActivity';
 import ExpensesThisMonth from './ui/expensesThisMonth';
 import ExpensesGraph from './ui/expensesGraph';
-import { useEffect, useState } from 'react';
 
-interface Group {
-  _id: string;
-  members: string[];
-}
-
-export default function Page() {
-  const [userGroups, setUserGroups] = useState<number>(0);
-  const [userFriends, setUserFriends] = useState<number>(0);
-
-  const { data } = useSession();
-  const userData = data?.user;
-  const sessionUserId = userData?.id;
-
-  const getUserFriends = async () => {
-    if (!sessionUserId) return;
- try {
-        const response = await fetch(`/api/users?id=${sessionUserId}`);
-    if (!response.ok) {
-      console.error('Failed to fetch user');
-      return;
-    }
-   const userData = await response.json();
-   if (!userData) {
-     return;
-   }
-   setUserFriends(userData.user.friends.length)
-    } catch (error) {
-      console.error('Failed to fetch user friends')
-    }
-  }
-
-  const getUserGroups = async () => {
-    if (!sessionUserId) return;
-    try {
-      const response = await fetch('api/groups');
-      const data = await response.json();
-      const userGroups = data.groups.filter((group: Group) =>
-        group.members.includes(sessionUserId)
-      );
-      setUserGroups(userGroups.length);
-    } catch (error) {
-      console.error('Failed to fetch groups')
-    }
-  }
-  
-  useEffect(() => {
-    getUserFriends();
-    getUserGroups();
-  }, [sessionUserId])
-
+export default function Page() {  
+const { userDetails, userGroups, userFriends } = useUserContext();
 
   return (
     <div className='relative'>
@@ -66,7 +16,7 @@ export default function Page() {
         className='bg-cover bg-center h-48 flex items-center justify-center relative rounded-lg mb-10'
         style={{ backgroundImage: 'url(https://via.placeholder.com/800x300)' }}>
         <Avatar className='absolute top-40 bottom-0 right-6  rounded-full w-24 h-24'>
-          <AvatarImage src={userData?.image ?? undefined} />
+          <AvatarImage src={userDetails?.image ?? undefined} />
           <AvatarFallback>CN</AvatarFallback>{' '}
         </Avatar>
       </div>
@@ -74,9 +24,9 @@ export default function Page() {
       {/* Content Below Banner */}
       <div className='p-4'>
         <h2 className='text-xl font-semibold'>
-          Hi {userData?.name || 'stranger'}!{' '}
+          Hi {userDetails?.firstName}!{' '}
           <span className='text-sm font-light text-grey sm:block md:inline md:ml-10'>
-            {userData?.email}
+            {userDetails?.email}
           </span>
         </h2>
 
@@ -89,10 +39,10 @@ export default function Page() {
           </div>
           <div className='flex flex-row gap-5'>
             <p>
-              Groups: <span className='font-bold'>{userGroups}</span>{' '}
+              Groups: <span className='font-bold'>{userGroups.length}</span>{' '}
             </p>
             <p>
-              Friends: <span className='font-bold'>{userFriends}</span>
+              Friends: <span className='font-bold'>{userFriends.length}</span>
             </p>
           </div>
         </div>

--- a/app/(dashboard)/ui/friendsList.tsx
+++ b/app/(dashboard)/ui/friendsList.tsx
@@ -1,56 +1,15 @@
 'use client'
 
+import { useUserContext } from '../../context/UserContext';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
-
-interface User {
-  _id: string;
-  firstName: string;
-  lastName: string;
-  image?: string;
-}
 
 const FriendsList: React.FC = () => {
 
-  const [userFriends, setUserFriends] = useState<User[]>([]);
-  const router = useRouter();
-  const { data } = useSession();
-  const userId = data?.user?.id;
-
-  const getSessionUserFriends = async () => {
-    if (!userId) return;
-    try {
-        const response = await fetch(`/api/users?id=${userId}`);
-    if (!response.ok) {
-      console.error('Failed to fetch user');
-      return;
-    }
-      const userData = await response.json();
-      console.log('friends', userData.user.friends)
-    const sessionUserFriends: string[] = userData.user.friends;
-    
-    const result = await fetch(`/api/users`);
-    if (!result.ok) {
-      console.error('Failed to fetch all users');
-      return;
-    }
-
-    const allUsersData = await result.json();
-    const friendsData = allUsersData.users.filter((user: User) => sessionUserFriends.includes(user._id));
-    setUserFriends(friendsData);
-    } catch (error) {
-      console.error('Error fetching friends:', error)
-    } 
-  };
-
-  useEffect(() => {
-    getSessionUserFriends();   
-  }, [userId]);
-
+const {  userFriends } = useUserContext();
+const router = useRouter();
 
   return (
     <div className='flex flex-col items-center justify-between mt-10 ml-2'>

--- a/app/(dashboard)/ui/groupsList.tsx
+++ b/app/(dashboard)/ui/groupsList.tsx
@@ -1,59 +1,15 @@
 'use client';
 
+import { useUserContext } from '../../context/UserContext';
 import { useRouter } from 'next/navigation';
-import { useSession } from 'next-auth/react';
 import { Button } from '@/components/ui/button';
 import Image from 'next/image';
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import { ScrollArea } from '@/components/ui/scroll-area';
-
-interface Group {
-  _id: string;
-  name: string;
-  members: string[];
-}
-
-interface ApiResponse {
-  success: boolean;
-  groups: Group[];
-}
 
 const GroupsList: React.FC = () => {
   const router = useRouter();
-  const { data } = useSession();
-  const userData = data?.user;
-
-  const [groups, setGroups] = useState<Group[]>([]);
-
-  useEffect(() => {
-    const fetchGroups = async () => {
-      try {
-        const response = await fetch('/api/groups');
-        if (!response.ok) {
-          throw new Error('Failed to fetch groups');
-        }
-        const data: ApiResponse = await response.json();
-        //filter groups where user is a member
-        if (data.success) {
-          const userGroups = userData?.id
-            ? data.groups.filter((group) =>
-              group.members.includes(userData.id!))
-            : [];
-          
-           setGroups(userGroups);  
-        } else {
-          console.error("Failed to fetch groups:", data)
-}
-       
-      } catch (error) {
-        console.error('Error fetching groups:', error);
-      }
-    };
-
-    if (userData) {
-      fetchGroups();
-    }
-  }, [userData]);
+  const {  userGroups } = useUserContext();
 
   return (
     <div className='flex flex-col items-center justify-between mt-10 ml-2'>
@@ -69,7 +25,7 @@ const GroupsList: React.FC = () => {
       {/* list */}
       <ScrollArea className='h-72 w-full '>
         <ul className='mt-5'>
-          {groups.map((group) => {
+          {userGroups.map((group) => {
             return (
               <li
                 key={group._id}

--- a/app/(dashboard)/ui/navlinks.tsx
+++ b/app/(dashboard)/ui/navlinks.tsx
@@ -1,6 +1,4 @@
 'use client'
-//links displayed at the sidenav
-//TO DO: update href's when navigation is ready
 
 import {
   CurrencyDollarIcon,

--- a/app/context/UserContext.tsx
+++ b/app/context/UserContext.tsx
@@ -1,0 +1,122 @@
+'use client'
+import React, { createContext, useContext, useState, useEffect } from 'react';
+import { useSession } from 'next-auth/react';
+
+interface User {
+  _id: string;
+  firstName: string;
+  lastName: string;
+  email: string;
+  image?: string;
+}
+
+interface Group {
+  _id: string;
+  name: string;
+  members: string[];
+}
+
+interface UserContextType {
+  userDetails: User;
+  userGroups: Group[];
+  userFriends: User[];
+}
+
+interface ApiResponse {
+  success: boolean;
+  groups: Group[];
+}
+
+const defaultUser: User = {
+  _id: '01',
+  firstName: 'Stranger',
+  lastName: '',
+  email: 'No email',
+  image: '',
+};
+
+const UserContext = createContext<UserContextType | undefined>(undefined);
+
+export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const { data } = useSession();
+  const [userDetails, setUserDetails] = useState<User>(defaultUser);
+  const [userGroups, setUserGroups] = useState<Group[]>([]);
+  const [userFriends, setUserFriends] = useState<User[]>([]);
+    const sessionUserId = data?.user?.id;
+    
+    useEffect(() => {
+
+        const getSessionUserFriends = async () => {
+            if (!sessionUserId || sessionUserId === '01') return;
+            try {
+                const response = await fetch(`/api/users?id=${sessionUserId}`);
+                if (!response.ok) {
+                    console.error('Failed to fetch user');
+                    return;
+                }
+                const userData = await response.json();
+                setUserDetails(userData.user);
+                console.log('friends', userData.user.friends);
+                const sessionUserFriends: string[] = userData.user.friends;
+
+                const result = await fetch(`/api/users`);
+                if (!result.ok) {
+                    console.error('Failed to fetch all users');
+                    return;
+                }
+
+                const allUsersData = await result.json();
+                const friendsData = allUsersData.users.filter((user: User) =>
+                    sessionUserFriends.includes(user._id)
+                );
+                setUserFriends(friendsData);
+            } catch (error) {
+                console.error('Error fetching friends:', error);
+            }
+        };
+        
+        const getSessionUserGroups = async () => {
+            if (!sessionUserId || sessionUserId === '01') return;
+            try {
+                const response = await fetch('/api/groups');
+                if (!response.ok) {
+                    throw new Error('Failed to fetch groups');
+                }
+                const data: ApiResponse = await response.json();
+                //filter groups where user is a member
+                if (data.success) {
+                    const sessionUserGroups = sessionUserId
+                        ? data.groups.filter((group) =>
+                            group.members.includes(sessionUserId)
+                        )
+                        : [];
+
+                    setUserGroups(sessionUserGroups);
+                } else {
+                    console.error('Failed to fetch groups:', data);
+                }
+            } catch (error) {
+                console.error('Error fetching groups:', error);
+            }
+        };
+       
+        getSessionUserFriends();
+        getSessionUserGroups();
+    }, [sessionUserId]);
+
+    return (
+        <UserContext.Provider value={{ userDetails, userGroups, userFriends }}>
+            {children}
+        </UserContext.Provider>
+    );
+};
+
+export const useUserContext = () => {
+    const context = useContext(UserContext);
+    if (!context) {
+        throw new Error('useUserContext must be used within a UserProvider');
+    }
+    return context;
+}

--- a/app/context/UserContext.tsx
+++ b/app/context/UserContext.tsx
@@ -13,7 +13,11 @@ interface User {
 interface Group {
   _id: string;
   name: string;
-  members: string[];
+    members: string[];
+    budget: number;
+    description: string;
+    expenses: string[];
+    invite_link: string;
 }
 
 interface UserContextType {
@@ -58,7 +62,6 @@ export const UserProvider: React.FC<{ children: React.ReactNode }> = ({
                 }
                 const userData = await response.json();
                 setUserDetails(userData.user);
-                console.log('friends', userData.user.friends);
                 const sessionUserFriends: string[] = userData.user.friends;
 
                 const result = await fetch(`/api/users`);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from "next/font/local";
 import "./globals.css";
 import OAuthSessionProvider from "./global-ui/next-auth-client/OAuthSessionProvider";
 import { UserProvider } from './context/UserContext'; 
+import { Toaster } from "@/components/ui/toaster";
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -33,6 +34,7 @@ export default function RootLayout({
         <OAuthSessionProvider>
           <UserProvider>{children}</UserProvider>
         </OAuthSessionProvider>
+        <Toaster/>
       </body>
     </html>
   );

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import localFont from "next/font/local";
 import "./globals.css";
 import OAuthSessionProvider from "./global-ui/next-auth-client/OAuthSessionProvider";
+import { UserProvider } from './context/UserContext'; 
 
 const geistSans = localFont({
   src: "./fonts/GeistVF.woff",
@@ -26,11 +27,12 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en">
+    <html lang='en'>
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
-        <OAuthSessionProvider>{children}</OAuthSessionProvider>
+        className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+        <OAuthSessionProvider>
+          <UserProvider>{children}</UserProvider>
+        </OAuthSessionProvider>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,26 +2,32 @@
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
 import Image from 'next/image';
+import Login from './login/page';
 
 export default function Home() {
   const { data } = useSession();
   const userName = data?.user?.name;
 
-  return (
-    <main className='h-screen flex flex-col items-center justify-center '>
-      <Image
-        className='mb-10'
-        width={200}
-        height={200}
-        src={'/images/logo/logo-color.png'}
-        alt='Logo'
-      />
-      <h1 className='mb-10'>Hi {userName}!</h1>
-      <Link
-        href={'/home'}
-        className='bg-green-300 p-3 rounded-md'>
-        Go to Dashboard
-      </Link>
-    </main>
-  );
+  if (userName) {
+     return (
+       <main className='h-screen flex flex-col items-center justify-center '>
+         <Image
+           className='mb-10'
+           width={200}
+           height={200}
+           src={'/images/logo/logo-color.png'}
+           alt='Logo'
+         />
+         <h1 className='mb-10'>Hi {userName}!</h1>
+         <Link
+           href={'/home'}
+           className='bg-green-300 p-3 rounded-md'>
+           Go to Dashboard
+         </Link>
+       </main>
+     );
+  } else {
+    return <Login />
+  }
+ 
 }

--- a/components/ui/hover-card.tsx
+++ b/components/ui/hover-card.tsx
@@ -1,0 +1,29 @@
+"use client"
+
+import * as React from "react"
+import * as HoverCardPrimitive from "@radix-ui/react-hover-card"
+
+import { cn } from "@/lib/utils"
+
+const HoverCard = HoverCardPrimitive.Root
+
+const HoverCardTrigger = HoverCardPrimitive.Trigger
+
+const HoverCardContent = React.forwardRef<
+  React.ElementRef<typeof HoverCardPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof HoverCardPrimitive.Content>
+>(({ className, align = "center", sideOffset = 4, ...props }, ref) => (
+  <HoverCardPrimitive.Content
+    ref={ref}
+    align={align}
+    sideOffset={sideOffset}
+    className={cn(
+      "z-50 w-64 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+      className
+    )}
+    {...props}
+  />
+))
+HoverCardContent.displayName = HoverCardPrimitive.Content.displayName
+
+export { HoverCard, HoverCardTrigger, HoverCardContent }

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -1,0 +1,129 @@
+"use client"
+
+import * as React from "react"
+import * as ToastPrimitives from "@radix-ui/react-toast"
+import { cva, type VariantProps } from "class-variance-authority"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const ToastProvider = ToastPrimitives.Provider
+
+const ToastViewport = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Viewport>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Viewport
+    ref={ref}
+    className={cn(
+      "fixed top-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      className
+    )}
+    {...props}
+  />
+))
+ToastViewport.displayName = ToastPrimitives.Viewport.displayName
+
+const toastVariants = cva(
+  "group pointer-events-auto relative flex w-full items-center justify-between space-x-4 overflow-hidden rounded-md border p-6 pr-8 shadow-lg transition-all data-[swipe=cancel]:translate-x-0 data-[swipe=end]:translate-x-[var(--radix-toast-swipe-end-x)] data-[swipe=move]:translate-x-[var(--radix-toast-swipe-move-x)] data-[swipe=move]:transition-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[swipe=end]:animate-out data-[state=closed]:fade-out-80 data-[state=closed]:slide-out-to-right-full data-[state=open]:slide-in-from-top-full data-[state=open]:sm:slide-in-from-bottom-full",
+  {
+    variants: {
+      variant: {
+        default: "border bg-background text-foreground",
+        destructive:
+          "destructive group border-destructive bg-destructive text-destructive-foreground",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Toast = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
+    VariantProps<typeof toastVariants>
+>(({ className, variant, ...props }, ref) => {
+  return (
+    <ToastPrimitives.Root
+      ref={ref}
+      className={cn(toastVariants({ variant }), className)}
+      {...props}
+    />
+  )
+})
+Toast.displayName = ToastPrimitives.Root.displayName
+
+const ToastAction = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Action>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Action
+    ref={ref}
+    className={cn(
+      "inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive",
+      className
+    )}
+    {...props}
+  />
+))
+ToastAction.displayName = ToastPrimitives.Action.displayName
+
+const ToastClose = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Close>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Close
+    ref={ref}
+    className={cn(
+      "absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus:outline-none focus:ring-2 group-hover:opacity-100 group-[.destructive]:text-red-300 group-[.destructive]:hover:text-red-50 group-[.destructive]:focus:ring-red-400 group-[.destructive]:focus:ring-offset-red-600",
+      className
+    )}
+    toast-close=""
+    {...props}
+  >
+    <X className="h-4 w-4" />
+  </ToastPrimitives.Close>
+))
+ToastClose.displayName = ToastPrimitives.Close.displayName
+
+const ToastTitle = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Title>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Title
+    ref={ref}
+    className={cn("text-sm font-semibold", className)}
+    {...props}
+  />
+))
+ToastTitle.displayName = ToastPrimitives.Title.displayName
+
+const ToastDescription = React.forwardRef<
+  React.ElementRef<typeof ToastPrimitives.Description>,
+  React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>
+>(({ className, ...props }, ref) => (
+  <ToastPrimitives.Description
+    ref={ref}
+    className={cn("text-sm opacity-90", className)}
+    {...props}
+  />
+))
+ToastDescription.displayName = ToastPrimitives.Description.displayName
+
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>
+
+type ToastActionElement = React.ReactElement<typeof ToastAction>
+
+export {
+  type ToastProps,
+  type ToastActionElement,
+  ToastProvider,
+  ToastViewport,
+  Toast,
+  ToastTitle,
+  ToastDescription,
+  ToastClose,
+  ToastAction,
+}

--- a/components/ui/toaster.tsx
+++ b/components/ui/toaster.tsx
@@ -1,0 +1,35 @@
+"use client"
+
+import { useToast } from "@/hooks/use-toast"
+import {
+  Toast,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from "@/components/ui/toast"
+
+export function Toaster() {
+  const { toasts } = useToast()
+
+  return (
+    <ToastProvider>
+      {toasts.map(function ({ id, title, description, action, ...props }) {
+        return (
+          <Toast key={id} {...props}>
+            <div className="grid gap-1">
+              {title && <ToastTitle>{title}</ToastTitle>}
+              {description && (
+                <ToastDescription>{description}</ToastDescription>
+              )}
+            </div>
+            {action}
+            <ToastClose />
+          </Toast>
+        )
+      })}
+      <ToastViewport />
+    </ToastProvider>
+  )
+}

--- a/hooks/use-toast.ts
+++ b/hooks/use-toast.ts
@@ -1,0 +1,194 @@
+"use client"
+
+// Inspired by react-hot-toast library
+import * as React from "react"
+
+import type {
+  ToastActionElement,
+  ToastProps,
+} from "@/components/ui/toast"
+
+const TOAST_LIMIT = 1
+const TOAST_REMOVE_DELAY = 1000000
+
+type ToasterToast = ToastProps & {
+  id: string
+  title?: React.ReactNode
+  description?: React.ReactNode
+  action?: ToastActionElement
+}
+
+const actionTypes = {
+  ADD_TOAST: "ADD_TOAST",
+  UPDATE_TOAST: "UPDATE_TOAST",
+  DISMISS_TOAST: "DISMISS_TOAST",
+  REMOVE_TOAST: "REMOVE_TOAST",
+} as const
+
+let count = 0
+
+function genId() {
+  count = (count + 1) % Number.MAX_SAFE_INTEGER
+  return count.toString()
+}
+
+type ActionType = typeof actionTypes
+
+type Action =
+  | {
+      type: ActionType["ADD_TOAST"]
+      toast: ToasterToast
+    }
+  | {
+      type: ActionType["UPDATE_TOAST"]
+      toast: Partial<ToasterToast>
+    }
+  | {
+      type: ActionType["DISMISS_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+  | {
+      type: ActionType["REMOVE_TOAST"]
+      toastId?: ToasterToast["id"]
+    }
+
+interface State {
+  toasts: ToasterToast[]
+}
+
+const toastTimeouts = new Map<string, ReturnType<typeof setTimeout>>()
+
+const addToRemoveQueue = (toastId: string) => {
+  if (toastTimeouts.has(toastId)) {
+    return
+  }
+
+  const timeout = setTimeout(() => {
+    toastTimeouts.delete(toastId)
+    dispatch({
+      type: "REMOVE_TOAST",
+      toastId: toastId,
+    })
+  }, TOAST_REMOVE_DELAY)
+
+  toastTimeouts.set(toastId, timeout)
+}
+
+export const reducer = (state: State, action: Action): State => {
+  switch (action.type) {
+    case "ADD_TOAST":
+      return {
+        ...state,
+        toasts: [action.toast, ...state.toasts].slice(0, TOAST_LIMIT),
+      }
+
+    case "UPDATE_TOAST":
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === action.toast.id ? { ...t, ...action.toast } : t
+        ),
+      }
+
+    case "DISMISS_TOAST": {
+      const { toastId } = action
+
+      // ! Side effects ! - This could be extracted into a dismissToast() action,
+      // but I'll keep it here for simplicity
+      if (toastId) {
+        addToRemoveQueue(toastId)
+      } else {
+        state.toasts.forEach((toast) => {
+          addToRemoveQueue(toast.id)
+        })
+      }
+
+      return {
+        ...state,
+        toasts: state.toasts.map((t) =>
+          t.id === toastId || toastId === undefined
+            ? {
+                ...t,
+                open: false,
+              }
+            : t
+        ),
+      }
+    }
+    case "REMOVE_TOAST":
+      if (action.toastId === undefined) {
+        return {
+          ...state,
+          toasts: [],
+        }
+      }
+      return {
+        ...state,
+        toasts: state.toasts.filter((t) => t.id !== action.toastId),
+      }
+  }
+}
+
+const listeners: Array<(state: State) => void> = []
+
+let memoryState: State = { toasts: [] }
+
+function dispatch(action: Action) {
+  memoryState = reducer(memoryState, action)
+  listeners.forEach((listener) => {
+    listener(memoryState)
+  })
+}
+
+type Toast = Omit<ToasterToast, "id">
+
+function toast({ ...props }: Toast) {
+  const id = genId()
+
+  const update = (props: ToasterToast) =>
+    dispatch({
+      type: "UPDATE_TOAST",
+      toast: { ...props, id },
+    })
+  const dismiss = () => dispatch({ type: "DISMISS_TOAST", toastId: id })
+
+  dispatch({
+    type: "ADD_TOAST",
+    toast: {
+      ...props,
+      id,
+      open: true,
+      onOpenChange: (open) => {
+        if (!open) dismiss()
+      },
+    },
+  })
+
+  return {
+    id: id,
+    dismiss,
+    update,
+  }
+}
+
+function useToast() {
+  const [state, setState] = React.useState<State>(memoryState)
+
+  React.useEffect(() => {
+    listeners.push(setState)
+    return () => {
+      const index = listeners.indexOf(setState)
+      if (index > -1) {
+        listeners.splice(index, 1)
+      }
+    }
+  }, [state])
+
+  return {
+    ...state,
+    toast,
+    dismiss: (toastId?: string) => dispatch({ type: "DISMISS_TOAST", toastId }),
+  }
+}
+
+export { useToast, toast }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-avatar": "^1.1.0",
     "@radix-ui/react-dialog": "^1.1.1",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
+    "@radix-ui/react-hover-card": "^1.1.2",
     "@radix-ui/react-label": "^2.1.0",
     "@radix-ui/react-popover": "^1.1.1",
     "@radix-ui/react-scroll-area": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@radix-ui/react-select": "^2.1.1",
     "@radix-ui/react-separator": "^1.1.0",
     "@radix-ui/react-slot": "^1.1.0",
+    "@radix-ui/react-toast": "^1.2.2",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "cmdk": "1.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@radix-ui/react-slot':
         specifier: ^1.1.0
         version: 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-toast':
+        specifier: ^1.2.2
+        version: 1.2.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -561,6 +564,15 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-context@1.1.1':
+    resolution: {integrity: sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   '@radix-ui/react-dialog@1.0.5':
     resolution: {integrity: sha512-GjWJX/AUpB703eEBanuBnIWdIXg6NvJFCXcNlSZk4xdszCdhrJgBoUd1cGk67vFO+WdA2pfI/plOpqz/5GUP6Q==}
     peerDependencies:
@@ -611,6 +623,19 @@ packages:
 
   '@radix-ui/react-dismissable-layer@1.1.0':
     resolution: {integrity: sha512-/UovfmmXGptwGcBQawLzvn2jOfM0t4z3/uKffoBlj724+n3FvBbZ7M0aaBOmkp6pqFYpO4yx8tSVJjx3Fl2jig==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.1':
+    resolution: {integrity: sha512-QSxg29lfr/xcev6kSz7MAlmDnzbP1eI/Dwn3Tp1ip0KT5CUELsxkekFEMVBEoykI3oV39hKT4TKZzBNMbcTZYQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -775,6 +800,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-portal@1.1.2':
+    resolution: {integrity: sha512-WeDYLGPxJb/5EGBoedyJbT0MpoULmwnIPMJMSldkuiMsBAv7N1cRdsTWZWht9vpPOiN3qyiGAtbK2is47/uMFg==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-presence@1.0.1':
     resolution: {integrity: sha512-UXLW4UAbIY5ZjcvzjfRFo5gxva8QirC9hF7wRE4U5gz+TP0DbRk+//qyuAQ1McDxBt1xNMBTaciFGvEmJvAZCg==}
     peerDependencies:
@@ -790,6 +828,19 @@ packages:
 
   '@radix-ui/react-presence@1.1.0':
     resolution: {integrity: sha512-Gq6wuRN/asf9H/E/VzdKoUtT8GC9PQc9z40/vEr0VCJ4u5XvvhWIrSsCB6vD2/cH7ugTdSfYq9fLJCcM00acrQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.1':
+    resolution: {integrity: sha512-IeFXVi4YS1K0wVZzXNrbaaUvIJ3qdY+/Ih4eHFhWA9SwGR9UDX7Ck8abvL57C4cv3wwMvUE0OG69Qc3NCcTe/A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -895,6 +946,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-toast@1.2.2':
+    resolution: {integrity: sha512-Z6pqSzmAP/bFJoqMAston4eSNa+ud44NSZTiZUmUen+IOZ5nBY8kzuU5WDBVyFXPtcW6yUalOHsxM/BP6Sv8ww==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-use-callback-ref@1.0.1':
@@ -3726,6 +3790,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.8
 
+  '@radix-ui/react-context@1.1.1(@types/react@18.3.8)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.8
+
   '@radix-ui/react-dialog@1.0.5(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
@@ -3792,6 +3862,19 @@ snapshots:
       '@types/react-dom': 18.3.0
 
   '@radix-ui/react-dismissable-layer@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-use-escape-keydown': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.8
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-dismissable-layer@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/primitive': 1.1.0
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
@@ -3966,6 +4049,16 @@ snapshots:
       '@types/react': 18.3.8
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-portal@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.8
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-presence@1.0.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
@@ -3978,6 +4071,16 @@ snapshots:
       '@types/react-dom': 18.3.0
 
   '@radix-ui/react-presence@1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.8
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-presence@1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
       '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.8)(react@18.3.1)
@@ -4092,6 +4195,26 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.8
+
+  '@radix-ui/react-toast@1.2.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-use-layout-effect': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-visually-hidden': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.8
+      '@types/react-dom': 18.3.0
 
   '@radix-ui/react-use-callback-ref@1.0.1(@types/react@18.3.8)(react@18.3.1)':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -23,6 +23,9 @@ importers:
       '@radix-ui/react-dropdown-menu':
         specifier: ^2.1.1
         version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-hover-card':
+        specifier: ^1.1.2
+        version: 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-label':
         specifier: ^2.1.0
         version: 2.1.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -693,6 +696,19 @@ packages:
 
   '@radix-ui/react-focus-scope@1.1.0':
     resolution: {integrity: sha512-200UD8zylvEyL8Bx+z76RJnASR2gRMuxlgFCPAe/Q/679a/r0eK3MBVYMb7vZODZcffZBdob1EGnky78xmVvcA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-hover-card@1.1.2':
+    resolution: {integrity: sha512-Y5w0qGhysvmqsIy6nQxaPa6mXNKznfoGjOfBgzOjocLxr2XlSjqBMYQQL+FfyogsMuX+m8cZyQGYhJxvxUzO4w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -3938,6 +3954,23 @@ snapshots:
       '@types/react': 18.3.8
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-hover-card@1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.1(@types/react@18.3.8)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.2(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.8)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.8)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.8
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-id@1.0.1(@types/react@18.3.8)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.25.6
@@ -5271,8 +5304,8 @@ snapshots:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.0(eslint@8.57.1)
       eslint-plugin-react: 7.36.1(eslint@8.57.1)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.57.1)
@@ -5291,37 +5324,37 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.3.7
       enhanced-resolve: 5.17.1
       eslint: 8.57.1
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       fast-glob: 3.3.2
       get-tsconfig: 4.8.1
       is-bun-module: 1.2.1
       is-glob: 4.0.3
     optionalDependencies:
-      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1)
+      eslint-plugin-import: 2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - '@typescript-eslint/parser'
       - eslint-import-resolver-node
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 7.2.0(eslint@8.57.1)(typescript@5.6.2)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3)(eslint@8.57.1):
+  eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.8
@@ -5332,7 +5365,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.11.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.3(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.30.0(@typescript-eslint/parser@7.2.0(eslint@8.57.1)(typescript@5.6.2))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.15.1
       is-glob: 4.0.3


### PR DESCRIPTION
# Description
Created pages to view all user friends and all user groups and be able to delete them


## Main changes explained:
- Created UI components to view friends and groups when clicking 'friends' and 'groups' links on the sidebar
- Added delete handlers to delete friends and groups
- Added success and error toasts to confirm deletion


## How to test:
1. check into current branch
2. do `pnpm install` and `pnpm run dev` to run this PR locally
3. login with a user who has friends and groups
4. go to `/home` 
5. click 'friends' and 'groups' on the sidebar
6. verify that you see user's groups and friends and can delete them
7. To view changes in the sidebar, you need to refresh the page

## Screenshots or videos of changes:

Friends:
![Screenshot 2024-10-14 at 11 53 16 AM](https://github.com/user-attachments/assets/a9cb0001-07b3-4f78-9a61-412ec4e0877b)

Groups:
![Screenshot 2024-10-14 at 11 53 03 AM](https://github.com/user-attachments/assets/0397f5c4-bba6-4af7-befe-aac9d261b8c0)


## Note:
Delete functionality for groups is not complete yet as I can not find the delete api route
