### PR TITLE
Created removeMember api to handle removal of member from group

### DIFF
--- a/app/api/groups/[groupId]/[memberId]/removeMember/route.ts
+++ b/app/api/groups/[groupId]/[memberId]/removeMember/route.ts
@@ -4,17 +4,16 @@ import dbConnect from "@/lib/dbConnect";
 import User from "@/models/Users";
 import UserExpense from "@/models/UserExpense";
 import UserGroup from "@/models/UserGroup";
+import { ObjectId } from "mongoose";
 
 
-export const DELETE = async (request: NextRequest, { params }: { params: { groupId: string } }) => {
+export const DELETE = async (request: NextRequest, { params }: { params: { groupId: string, memberId: ObjectId} }) => {
   try {
     await dbConnect();
 
-    const { groupId } = params;
-    const body = await request.json();
-    const { userId } = body
+    const { groupId, memberId } = params;
 
-    const userExists = await User.findById(userId)
+    const userExists = await User.findById(memberId)
 
     if (!userExists) {
       return NextResponse.json({error: "No user with that id"}, {status: 404})
@@ -26,21 +25,21 @@ export const DELETE = async (request: NextRequest, { params }: { params: { group
       return NextResponse.json({error: "No group with that id"}, {status: 404})
     }
 
-    const userInGroup = group.members.includes(userId)
+    const userInGroup = group.members.includes(memberId)
 
     if (!userInGroup) {
       return NextResponse.json({error: "The user is not in apart of this group"}, {status: 400})
     }
 
-    group = await Group.findByIdAndUpdate(groupId, { //remove the id of the user from the members array.
-      $pull: { members: userId }
+    group = await Group.findByIdAndUpdate(groupId, { //removes the id of the user from the members array.
+      $pull: { members: memberId }
     }, { new: true })
 
-    const userGroup = await UserGroup.findOneAndDelete({ group_id: groupId, user_id: userId }); //delete the UserGroup record.
+    const userGroup = await UserGroup.findOneAndDelete({ group_id: groupId, user_id: memberId }); // deletes the UserGroup record.
     console.log("user group", userGroup)
 
     const expenses = await UserExpense.deleteMany({ // removes all user expenses record that is related to expenses in the current group.
-      user_id: userId,
+      user_id: memberId,
       expense_id: { $in: group!.expenses }
     });
 

--- a/app/api/groups/[groupId]/removeMember/route.ts
+++ b/app/api/groups/[groupId]/removeMember/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import Group from "@/models/Group";
+import dbConnect from "@/lib/dbConnect";
+import User from "@/models/Users";
+import UserExpense from "@/models/UserExpense";
+import UserGroup from "@/models/UserGroup";
+
+
+export const DELETE = async (request: NextRequest, { params }: { params: { groupId: string } }) => {
+  try {
+    await dbConnect();
+
+    const { groupId } = params;
+    const body = await request.json();
+    const { userId } = body
+
+    const userExists = await User.findById(userId)
+
+    if (!userExists) {
+      return NextResponse.json({error: "No user with that id"}, {status: 404})
+    }
+
+    let group = await Group.findById(groupId);
+
+    if (!group) {
+      return NextResponse.json({error: "No group with that id"}, {status: 404})
+    }
+
+    const userInGroup = group.members.includes(userId)
+
+    if (!userInGroup) {
+      return NextResponse.json({error: "The user is not in apart of this group"}, {status: 400})
+    }
+
+    group = await Group.findByIdAndUpdate(groupId, { //remove the id of the user from the members array.
+      $pull: { members: userId }
+    }, { new: true })
+
+    const userGroup = await UserGroup.findOneAndDelete({ group_id: groupId, user_id: userId }); //delete the UserGroup record.
+    console.log("user group", userGroup)
+
+    const expenses = await UserExpense.deleteMany({ // removes all user expenses record that is related to expenses in the current group.
+      user_id: userId,
+      expense_id: { $in: group!.expenses }
+    });
+
+    console.log("expenses", expenses)
+
+    return NextResponse.json({message: "Member successfully removed", group})
+  } catch (error) {
+    return NextResponse.json({error: error});
+  }
+}


### PR DESCRIPTION
# Description
This commit implements functionality to remove members from a group.

## Related to the following Jira/Trello issue 
N/A

## Main changes explained:
- Created removeMember api to handle removing members from group.

## How to test:
1. check into current branch
2. do `pnpm install` and `pnpm run dev` to run this PR locally
3. Create a DELETE request to http://localhost:3000/api/groups/*insert group id here*/*member id goes here*/removeMember
5. Verify the removal of the member from the group. The message should return the updated group without the id of the member in it. I added console logs to show records of userGroup records that were removed and the number of userExpense records that were removed, instead of going through the database and manually checking it. You should see that in the terminal after the request is complete.

## Note:
I think only the admin / the person should be able to remove themself from a group. I believe the logic to check who is who can be handled client-side.
